### PR TITLE
Remove hint about OOP

### DIFF
--- a/src/04_thinking_in_rust.md
+++ b/src/04_thinking_in_rust.md
@@ -3,8 +3,8 @@
 Aside of the obvious type system stuff, I think there are a few core differences
 between Rust and JS:
 
-### Object-Oriented everything
-In Rust *everything* is object-oriented. Imports are always done through
+### Namespaces
+In Rust, imports are always done through
 namespaces, and namespaces kind of behave like structs.
 
 ```rust


### PR DESCRIPTION
> In Rust, *everything* is object-oriented. 

This statement seemed very odd to me. Sure enough, Rust is not an object oriented language. Therefore, this statement might be misleading. I propose to remove the claim, and instead focus on the also mentioned namespaces instead.

### References
https://doc.rust-lang.org/book/ch17-00-oop.html